### PR TITLE
Provide all arguments to FormErrorNormalizer

### DIFF
--- a/src/Resources/config/transformers.yml
+++ b/src/Resources/config/transformers.yml
@@ -30,4 +30,5 @@ services:
     tags:
       - { name: serializer.normalizer, priority: -10 }
     arguments:
-      [ '@translator' ]
+      - '@translator'
+      - 'Valantic\PimcoreFormsBundle\Repository\ConfigurationRepository'


### PR DESCRIPTION
Fixes an old bug which would pop up in Sentry etc. but didn't result in any apparent errors, caused by not providing all arguments to the `FormErrorNormalizer` via the Symfony Service Container.