### PR TITLE
Translate choice_attr labels for correct matching

### DIFF
--- a/src/Form/Builder.php
+++ b/src/Form/Builder.php
@@ -111,15 +111,22 @@ class Builder
             if (
                 empty($definition['provider'])
                 && $formConfig['translate']['inline_choices']
-                && array_key_exists('choices', $definition['options'])
             ) {
-                $options['choices'] = array_combine(
-                    array_map(
-                        fn (string $key): string => $this->translator->trans($key),
-                        array_keys($definition['options']['choices'])
-                    ),
-                    $definition['options']['choices']
-                );
+                // Attribute(s) are matched via label hence both the actual label
+                // and the "attribute label" need to be translated.
+                foreach (['choices', 'choice_attr'] as $key) {
+                    if (!array_key_exists($key, $definition['options'])) {
+                        continue;
+                    }
+
+                    $options[$key] = array_combine(
+                        array_map(
+                            fn (string $key): string => $this->translator->trans($key),
+                            array_keys($definition['options'][$key])
+                        ),
+                        $definition['options'][$key]
+                    );
+                }
             }
             if (!empty($definition['provider']) && is_string($definition['provider'])) {
                 /** @var ChoicesInterface $choices */


### PR DESCRIPTION
Say a form has this field:

```yaml
choices:
  E-Mail: 'email'
  Phone: 'phone'
choice_attr:
  Phone:
    data-icon: 'i-contact'
  E-Mail:
    data-icon: 'i-email'
```

And the following translation table:

|key|value|
|---|---|
|E-Mail|E-mail|

Then the form is translated as:

```yaml
choices:
  E-mail: 'email'
  Phone: 'phone'
choice_attr:
  Phone:
    data-icon: 'i-contact'
  E-Mail:
    data-icon: 'i-email'
```

Which results in this JSON:

```json
"choices":[
  {
    "label":"E-mail",
    "value":"email",
    "data":"email",
    "attr":[
      
    ],
    "labelTranslationParameters":[
      
    ]
  },
  {
    "label":"Phone",
    "value":"phone",
    "data":"phone",
    "attr":{
      "dataIcon":"i-contact"
    },
    "labelTranslationParameters":[
      
    ]
  }
]
```

This is caused by the non-matching labels in `choices` (`E-mail`) and `choice_attr` (`E-Mail`) after the partial translation.

Once the "labels" in `choice_attr` are translated as well, both choices have the attribute set correctly:

```json
"choices":[
  {
    "label":"E-mail",
    "value":"email",
    "data":"email",
    "attr":{
      "dataIcon":"i-email"
    },
    "labelTranslationParameters":[
      
    ]
  },
  {
    "label":"Phone",
    "value":"phone",
    "data":"phone",
    "attr":{
      "dataIcon":"i-contact"
    },
    "labelTranslationParameters":[
      
    ]
  }
]
```